### PR TITLE
build: remove apt caching from dockerfile

### DIFF
--- a/.github/workflows/build-scan-push.yaml
+++ b/.github/workflows/build-scan-push.yaml
@@ -30,7 +30,7 @@ jobs:
   # The build job uses the build-scan-push reusable workflow
   build:
     needs: release
-    uses: liatrio/github-workflows/.github/workflows/build-scan-push.yaml@main
+    uses: liatrio/github-workflows/.github/workflows/build-scan-push.yaml@v0.2.0
     with:
       publish: ${{ github.ref == 'refs/heads/main' }}
       repository: ghcr.io
@@ -38,5 +38,6 @@ jobs:
       tag: ${{ needs.release.outputs.newVersion }}
       image-name: ${{ github.event.repository.name }}
       nofail: true
+      timeout: 10m
     secrets:
       registry-password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-scan.yml
+++ b/.github/workflows/build-scan.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    uses: liatrio/github-workflows/.github/workflows/build-scan-push.yaml@main
+    uses: liatrio/github-workflows/.github/workflows/build-scan-push.yaml@v0.2.0
     with:
       publish: false
       repository: ghcr.io
@@ -17,5 +17,6 @@ jobs:
       tag: test
       image-name: ${{ github.event.repository.name }}
       nofail: true
+      timeout: 10m
     secrets:
       registry-password: ${{ secrets.GITHUB_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN curl -sL https://packages.microsoft.com/keys/microsoft.asc | \
     tee /etc/apt/trusted.gpg.d/microsoft.gpg > /dev/null && \
     echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $(lsb_release -cs) main" | \
     tee /etc/apt/sources.list.d/azure-cli.list && \
-    apt-get update && apt-get install -yq azure-cli && \
+    apt-get update && apt-get install -yq azure-cli && apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
     az extension add --system --name azure-devops && \
     az -v


### PR DESCRIPTION
image-builder-azure-terraform was scheduled workflow failed due to trivy getting timed out after 5 minutes.

- Did some optimization with removing the apt cache from the dockerfile.
- extended the timer for trivy timing out which we have a set parameter in v0.2.0 of build-scan-push reusable workflow.